### PR TITLE
Fix routing case for Blog pages

### DIFF
--- a/src/components/BlogCard.jsx
+++ b/src/components/BlogCard.jsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 const BlogCard = ({ title, date, content, slug }) => {
   return (
     <Link
-      to={`/blog/${slug}`}
+      to={`/Blog/${slug}`}
       className="rounded-sm border-2 text-neutral-200 p-5 flex items-center justify-between"
     >
       <div className="text-neutral-300">

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -18,7 +18,7 @@ function Header(props) {
       location.pathname === "/Contact" ||
       location.pathname === "/Cert" ||
       location.pathname.startsWith("/Projects/") ||
-      location.pathname.startsWith("/blog/")
+      location.pathname.startsWith("/Blog/")
     ) {
       textColor.set("#f0f9ff");
     } else {
@@ -37,7 +37,7 @@ function Header(props) {
     location.pathname === "/Contact" ||
     location.pathname === "/Cert" ||
     location.pathname.startsWith("/Projects/") ||
-    location.pathname.startsWith("/blog/")
+    location.pathname.startsWith("/Blog/")
       ? "bg-neutral-950"
       : "bg-transparent";
   return (


### PR DESCRIPTION
## Summary
- ensure blog links use `/Blog` path
- update header pathname checks for new case

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684309797a34832e99c06a95f0549353